### PR TITLE
removed ignored faker errors on phpstan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,11 +3,3 @@ parameters:
         -
             message: "#^Call to an undefined method Knp\\\\DoctrineBehaviors\\\\Contract\\\\Entity\\\\TranslationInterface\\:\\:#"
             path: .
-
-        -
-            message: "#^Call to an undefined method Faker\\\\UniqueGenerator\\:\\:languageCode\\(\\)\\.$#"
-            path: .
-
-        -
-            message: "#^Call to an undefined method Faker\\\\UniqueGenerator\\:\\:slug\\(\\)\\.$#"
-            path: .


### PR DESCRIPTION
removed phpstan ignore errors

1. Ignored error pattern #^Call to an undefined method Faker\\UniqueGenerator\:\:languageCode\(\)\.$# in path 
   /Users/rocio/repositories/forkedRunroomSamplesBundle was not matched in reported errors.

2. Ignored error pattern #^Call to an undefined method Faker\\UniqueGenerator\:\:slug\(\)\.$# in path 
    /Users/rocio/repositories/forkedRunroomSamplesBundle was not matched in reported errors.